### PR TITLE
Unit tests and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Ignore bundler config.
 /.bundle
 .bonanza_conf.yml
+
+# Un-ignore the test fixture .bonanza.yml (typically ignored globally).
+!test/fixtures/repo/.bonanza.yml

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ gem "amazing_print", "~> 2.0"
 gem "logger", "~> 1.7"
 gem "paint", "~> 2.3"
 gem "terminal-table", "~> 4.0"
+
+group :test do
+  gem "minitest", "~> 5.25"
+  gem "rake", "~> 13.2"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,9 @@ GEM
   specs:
     amazing_print (2.0.0)
     logger (1.7.0)
+    minitest (5.27.0)
     paint (2.3.0)
+    rake (13.4.2)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     unicode-display_width (3.2.0)
@@ -19,7 +21,9 @@ PLATFORMS
 DEPENDENCIES
   amazing_print (~> 2.0)
   logger (~> 1.7)
+  minitest (~> 5.25)
   paint (~> 2.3)
+  rake (~> 13.2)
   terminal-table (~> 4.0)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -44,6 +44,37 @@ label_colors:
 
 Change to your project's directory, and run `bonanza` (or the alias you chose) to see the dashboard.
 
+## Testing
+
+The test suite uses [minitest](https://github.com/minitest/minitest) and lives in `test/`.
+
+```sh
+bundle install
+bundle exec rake test
+```
+
+Layout:
+- `test/test_helper.rb` — boots a minimal `Bonanza` module
+- `test/fixtures/` — fixtures used by tests
+- `test/bonanza/` — mirrors `lib/bonanza/`, one `*_test.rb` per class
+
+By default each test boots `Bonanza.config` from the fixture `.bonanza.yml`. To override values for a single test, wrap the assertion in `with_config`:
+
+```ruby
+with_config("author_colors" => { "monalisa" => :red }) do
+  # Bonanza.config.author_colors is { "monalisa" => :red } in here
+end
+```
+
+To capture a fresh fixture from a real repo:
+
+```sh
+cd /path/to/repo
+PAGER=cat gh pr list --state open --limit 5 \
+  --json title,reviewDecision,latestReviews,number,author,assignees,isDraft,labels,updatedAt,url \
+  > /path/to/bonanza/test/fixtures/<name>.json
+```
+
 ## FAQ
 
 **What are the different dashboard sections?**

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.warning = false
+end
+
+task default: :test

--- a/bin/bonanza
+++ b/bin/bonanza
@@ -4,4 +4,4 @@ bonanza_exec="$(dirname "$(realpath "$0")")"
 bonanza_dir="$bonanza_exec/../"
 repo_dir=$PWD
 
-zsh -c "cd $bonanza_dir && ruby ./lib/bonanza.rb $repo_dir '$@'"
+zsh -c "cd $bonanza_dir && ruby -r ./lib/bonanza -e 'Bonanza.run(ARGV.shift)' $repo_dir '$@'"

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -1,6 +1,9 @@
 # full or compact
 display_mode: full
 
+# Set to false to disable ANSI color escapes (useful for tests or piping output)
+colorize: true
+
 # Your github username
 gh_handle:
 

--- a/lib/bonanza.rb
+++ b/lib/bonanza.rb
@@ -18,33 +18,35 @@ require_relative "bonanza/formatter"
 module Bonanza
   class Error < StandardError; end
 
+  class << self
+    attr_accessor :repo_path
+    attr_writer :config, :options
+  end
+
   def self.logger
-    @@logger ||= Logger.new($stdout, progname: "BONANZA")
+    @logger ||= Logger.new($stdout, progname: "BONANZA")
   end
 
   def self.log_verbose(message)
     logger.debug(message) if options["verbose"]
   end
 
-  def self.repo_path
-    @@repo_path
-  end
-
-  def self.repo_path=(path)
-    @@repo_path = path
-  end
-
   def self.options
-    @@options ||= Bonanza::Options.parse
+    @options ||= Bonanza::Options.parse
   end
 
   def self.config
-    @@config ||= Bonanza::Config.new(repo_path, options)
+    @config ||= Bonanza::Config.new(repo_path, options)
+  end
+
+  def self.boot(repo_path)
+    self.repo_path = repo_path
+    logger
+    config
+  end
+
+  def self.run(repo_path)
+    boot(repo_path)
+    Dashboard.new.render
   end
 end
-
-# Initialize the config
-Bonanza.repo_path = ARGV[0]
-Bonanza.config
-
-Bonanza::Dashboard.new.render

--- a/lib/bonanza/config.rb
+++ b/lib/bonanza/config.rb
@@ -23,7 +23,8 @@ module Bonanza
   private
 
     def load_default_config
-      @default_config = YAML.load_file("config/defaults.yml")
+      defaults_path = File.expand_path("../../config/defaults.yml", __dir__)
+      @default_config = YAML.load_file(defaults_path)
     end
 
     def load_user_config

--- a/lib/bonanza/formatter.rb
+++ b/lib/bonanza/formatter.rb
@@ -137,6 +137,7 @@ module Bonanza
 
     def self.colorize(value, color: nil)
       return value unless color
+      return value unless Bonanza.config.colorize
 
       # Default to amazing_print colors, otherwise use Paint
       # https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart

--- a/lib/bonanza/options.rb
+++ b/lib/bonanza/options.rb
@@ -6,6 +6,7 @@ module Bonanza
     def self.parse
       options = {}
       OptionParser.new do |parser|
+        parser.program_name = "bonanza"
 
         parser.on("-v", "--verbose", "Run with logging") do |args|
           options["verbose"] = true

--- a/test/bonanza/config_test.rb
+++ b/test/bonanza/config_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "tmpdir"
+
+class ConfigTest < Minitest::Test
+
+  def with_repo(user_config)
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, ".bonanza.yml"), YAML.dump(user_config))
+      yield dir
+    end
+  end
+
+  def test_loads_default_values_and_merges_user_config
+    with_repo("gh_handle" => "vangogh") do |dir|
+      config = Bonanza::Config.new(dir)
+
+      assert_equal "vangogh", config.gh_handle
+      assert_equal 20,        config.search_limit  # from defaults
+      assert_equal "full",    config.display_mode  # from defaults
+    end
+  end
+
+  def test_user_config_overrides_defaults
+    with_repo("gh_handle" => "vangogh", "search_limit" => 5) do |dir|
+      config = Bonanza::Config.new(dir)
+      assert_equal 5, config.search_limit
+    end
+  end
+
+  def test_options_override_user_config
+    with_repo("gh_handle" => "vangogh", "display_mode" => "full") do |dir|
+      config = Bonanza::Config.new(dir, "display_mode" => "compact")
+      assert_equal "compact", config.display_mode
+    end
+  end
+
+  def test_method_missing_returns_values_for_known_keys
+    with_repo("gh_handle" => "vangogh", "author_colors" => { "vangogh" => "blue" }) do |dir|
+      config = Bonanza::Config.new(dir)
+      assert_equal({ "vangogh" => "blue" }, config.author_colors)
+    end
+  end
+
+  def test_method_missing_falls_through_for_unknown_keys
+    with_repo("gh_handle" => "vangogh") do |dir|
+      config = Bonanza::Config.new(dir)
+      assert_raises(NoMethodError) { config.nonexistent_key }
+    end
+  end
+
+  def test_respond_to_reports_true_for_known_keys
+    with_repo("gh_handle" => "vangogh") do |dir|
+      config = Bonanza::Config.new(dir)
+      assert config.respond_to?(:gh_handle)
+      refute config.respond_to?(:totally_made_up_key)
+    end
+  end
+
+  def test_raises_when_no_user_config_present
+    Dir.mktmpdir do |dir|
+      error = assert_raises(Bonanza::Error) { Bonanza::Config.new(dir) }
+      assert_match(/Must specify a valid path/, error.message)
+    end
+  end
+
+  def test_raises_when_gh_handle_is_blank
+    with_repo("gh_handle" => "") do |dir|
+      error = assert_raises(Bonanza::Error) { Bonanza::Config.new(dir) }
+      assert_match(/gh_handle/, error.message)
+    end
+  end
+
+end

--- a/test/bonanza/formatter_test.rb
+++ b/test/bonanza/formatter_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class FormatterTest < Minitest::Test
+
+  # --- get_review_status ----------------------------------------------------
+
+  def test_get_review_status_returns_empty_for_drafts
+    pr = { "isDraft" => true, "reviewDecision" => "REVIEW_REQUIRED" }
+    assert_equal "", Bonanza::Formatter.get_review_status(pr)
+  end
+
+  def test_get_review_status_treats_empty_review_decision_as_required
+    pr = { "isDraft" => false, "reviewDecision" => "" }
+    assert_equal "REQUIRED", Bonanza::Formatter.get_review_status(pr)
+  end
+
+  def test_get_review_status_treats_nil_review_decision_as_required
+    pr = { "isDraft" => false, "reviewDecision" => nil }
+    assert_equal "REQUIRED", Bonanza::Formatter.get_review_status(pr)
+  end
+
+  def test_get_review_status_maps_review_required_to_required
+    pr = { "isDraft" => false, "reviewDecision" => "REVIEW_REQUIRED" }
+    assert_equal "REQUIRED", Bonanza::Formatter.get_review_status(pr)
+  end
+
+  def test_get_review_status_maps_changes_requested_to_rejected
+    pr = { "isDraft" => false, "reviewDecision" => "CHANGES_REQUESTED" }
+    assert_equal "REJECTED", Bonanza::Formatter.get_review_status(pr)
+  end
+
+  def test_get_review_status_passes_through_approved
+    pr = { "isDraft" => false, "reviewDecision" => "APPROVED" }
+    assert_equal "APPROVED", Bonanza::Formatter.get_review_status(pr)
+  end
+
+  # --- get_my_review_status -------------------------------------------------
+
+  def test_get_my_review_status_returns_nil_with_no_reviews
+    assert_nil Bonanza::Formatter.get_my_review_status(pr_fixture(101))
+  end
+
+  def test_get_my_review_status_returns_state_when_user_has_reviewed
+    assert_equal "COMMENTED", Bonanza::Formatter.get_my_review_status(pr_fixture(102))
+    assert_equal "APPROVED",  Bonanza::Formatter.get_my_review_status(pr_fixture(106))
+  end
+
+  def test_get_my_review_status_ignores_reviews_from_other_users
+    assert_nil Bonanza::Formatter.get_my_review_status(pr_fixture(103))
+  end
+
+  # --- format_priority ------------------------------------------------------
+
+  def test_format_priority_uses_review_required_when_not_yet_approved
+    assert_equal 0, Bonanza::Formatter.format_priority(pr_fixture(102))
+    assert_equal 0, Bonanza::Formatter.format_priority(pr_fixture(105))
+  end
+
+  def test_format_priority_uses_rejected_for_changes_requested
+    assert_equal 1, Bonanza::Formatter.format_priority(pr_fixture(104))
+  end
+
+  def test_format_priority_uses_approved_when_pr_is_approved
+    assert_equal 2, Bonanza::Formatter.format_priority(pr_fixture(103))
+  end
+
+  def test_format_priority_prefers_my_approval_over_required
+    # PR 106: overall REVIEW_REQUIRED, but current_user has approved.
+    assert_equal 2, Bonanza::Formatter.format_priority(pr_fixture(106))
+  end
+
+  def test_format_priority_places_drafts_last
+    assert_equal 3, Bonanza::Formatter.format_priority(pr_fixture(101))
+  end
+
+  # --- format_done ----------------------------------------------------------
+
+  def test_format_done_marks_drafts_as_done
+    assert_equal " 🟢", Bonanza::Formatter.format_done(pr_fixture(101))
+  end
+
+  def test_format_done_marks_approved_prs_as_done
+    assert_equal " 🟢", Bonanza::Formatter.format_done(pr_fixture(103))
+  end
+
+  def test_format_done_marks_rejected_prs_as_done
+    assert_equal " 🟢", Bonanza::Formatter.format_done(pr_fixture(104))
+  end
+
+  def test_format_done_marks_pr_as_done_when_i_have_approved
+    assert_equal " 🟢", Bonanza::Formatter.format_done(pr_fixture(106))
+  end
+
+  def test_format_done_marks_required_review_as_not_done
+    assert_equal " ⭕️", Bonanza::Formatter.format_done(pr_fixture(102))
+    assert_equal " ⭕️", Bonanza::Formatter.format_done(pr_fixture(105))
+  end
+
+  # --- format_title ---------------------------------------------------------
+
+  def test_format_title_prefixes_pr_number
+    formatted = Bonanza::Formatter.format_title(pr_fixture(101))
+    assert_includes formatted, "PR 101: Add Starry Night background to login flow"
+  end
+
+  def test_format_title_truncates_long_titles
+    formatted = Bonanza::Formatter.format_title(pr_fixture(103))
+    title_part = formatted.sub(/^PR 103: /, "")
+    assert_equal 55, title_part.length
+    assert title_part.end_with?("..."), "expected truncated title to end with '...' (got #{title_part.inspect})"
+  end
+
+  # --- format_author --------------------------------------------------------
+
+  def test_format_author_returns_author_login
+    assert_equal "munch", Bonanza::Formatter.format_author(pr_fixture(102))
+  end
+
+  # --- format_assignees -----------------------------------------------------
+
+  def test_format_assignees_returns_empty_string_when_none
+    assert_equal "", Bonanza::Formatter.format_assignees(pr_fixture(101))
+  end
+
+  def test_format_assignees_limits_to_two
+    assert_equal "current_user, davinci", Bonanza::Formatter.format_assignees(pr_fixture(102))
+  end
+
+  # --- format_labels --------------------------------------------------------
+
+  def test_format_labels_returns_empty_string_when_none
+    assert_equal "", Bonanza::Formatter.format_labels(pr_fixture(104))
+  end
+
+  def test_format_labels_sorts_and_limits_to_three
+    # Labels are sorted alphabetically and capped at 3 (tech-debt drops off).
+    assert_equal "backend, critical, should-be-truncated",
+                 Bonanza::Formatter.format_labels(pr_fixture(103))
+  end
+
+  # --- format_draft ---------------------------------------------------------
+
+  def test_format_draft_distinguishes_draft_from_open
+    assert_equal "Draft", Bonanza::Formatter.format_draft(pr_fixture(101))
+    assert_equal "Open",  Bonanza::Formatter.format_draft(pr_fixture(102))
+  end
+
+  # --- format_updated_at ----------------------------------------------------
+
+  def test_format_updated_at_renders_localized_time_string
+    pr = { "updatedAt" => "2026-05-11T22:00:00Z" }
+    expected = Time.parse(pr["updatedAt"]).localtime.strftime("%a %b %d @ %k:%M")
+    assert_equal expected, Bonanza::Formatter.format_updated_at(pr)
+  end
+
+  # --- format (integration-style) -------------------------------------------
+
+  def test_format_assigns_all_expected_keys_and_preserves_others
+    pr = pr_fixture(102)
+    formatted = Bonanza::Formatter.format(pr)
+
+    # Adds computed columns
+    assert_equal 0, formatted["priority"]
+    %w[done myReview reviewDecision title author assignees labels isDraft updatedAt].each do |key|
+      assert formatted.key?(key), "expected formatted PR to have #{key}"
+    end
+
+    # Original keys still present
+    assert_equal 102, formatted["number"]
+    assert_equal "https://github.com/example/repo/pull/102", formatted["url"]
+  end
+
+end

--- a/test/fixtures/pr_list.json
+++ b/test/fixtures/pr_list.json
@@ -1,0 +1,117 @@
+[
+  {
+    "number": 101,
+    "title": "Add Starry Night background to login flow",
+    "url": "https://github.com/example/repo/pull/101",
+    "isDraft": true,
+    "reviewDecision": "REVIEW_REQUIRED",
+    "author": { "login": "vangogh", "name": "Vincent van Gogh" },
+    "assignees": [],
+    "labels": [
+      { "name": "frontend", "color": "0052cc" },
+      { "name": "review-app", "color": "6733ff" }
+    ],
+    "latestReviews": [],
+    "updatedAt": "2026-05-11T22:00:00Z"
+  },
+  {
+    "number": 102,
+    "title": "Fix race condition in The Scream notification dispatcher",
+    "url": "https://github.com/example/repo/pull/102",
+    "isDraft": false,
+    "reviewDecision": "REVIEW_REQUIRED",
+    "author": { "login": "munch", "name": "Edvard Munch" },
+    "assignees": [
+      { "login": "current_user" },
+      { "login": "davinci" },
+      { "login": "dali" }
+    ],
+    "labels": [
+      { "name": "backend", "color": "FBCA04" }
+    ],
+    "latestReviews": [
+      {
+        "author": { "login": "current_user" },
+        "state": "COMMENTED",
+        "submittedAt": "2026-05-11T18:00:00Z"
+      }
+    ],
+    "updatedAt": "2026-05-11T20:00:00Z"
+  },
+  {
+    "number": 103,
+    "title": "Refactor: extract Persistence of Memory caching layer into its own module for reuse",
+    "url": "https://github.com/example/repo/pull/103",
+    "isDraft": false,
+    "reviewDecision": "APPROVED",
+    "author": { "login": "current_user", "name": "Current User" },
+    "assignees": [],
+    "labels": [
+      { "name": "backend", "color": "FBCA04" },
+      { "name": "critical", "color": "B60205" },
+      { "name": "tech-debt", "color": "CCCCCC" },
+      { "name": "should-be-truncated", "color": "000000" }
+    ],
+    "latestReviews": [
+      {
+        "author": { "login": "davinci" },
+        "state": "APPROVED",
+        "submittedAt": "2026-05-10T15:00:00Z"
+      },
+      {
+        "author": { "login": "vangogh" },
+        "state": "APPROVED",
+        "submittedAt": "2026-05-10T16:00:00Z"
+      }
+    ],
+    "updatedAt": "2026-05-10T16:00:00Z"
+  },
+  {
+    "number": 104,
+    "title": "Fix Composition VIII tile alignment in gallery view",
+    "url": "https://github.com/example/repo/pull/104",
+    "isDraft": false,
+    "reviewDecision": "CHANGES_REQUESTED",
+    "author": { "login": "kandinsky", "name": "Wassily Kandinsky" },
+    "assignees": [],
+    "labels": [],
+    "latestReviews": [
+      {
+        "author": { "login": "current_user" },
+        "state": "CHANGES_REQUESTED",
+        "submittedAt": "2026-05-09T10:00:00Z"
+      }
+    ],
+    "updatedAt": "2026-05-09T10:00:00Z"
+  },
+  {
+    "number": 105,
+    "title": "Wire up feature flag for experimental Two Fridas layout",
+    "url": "https://github.com/example/repo/pull/105",
+    "isDraft": false,
+    "reviewDecision": "",
+    "author": { "login": "kahlo", "name": "Frida Kahlo" },
+    "assignees": [],
+    "labels": [],
+    "latestReviews": [],
+    "updatedAt": "2026-04-01T12:00:00Z"
+  },
+  {
+    "number": 106,
+    "title": "Bump dependencies for Guernica image processor",
+    "url": "https://github.com/example/repo/pull/106",
+    "isDraft": false,
+    "reviewDecision": "REVIEW_REQUIRED",
+    "author": { "login": "picasso", "name": "Pablo Picasso" },
+    "assignees": [],
+    "labels": [],
+    "latestReviews": [
+      {
+        "author": { "login": "current_user" },
+        "state": "APPROVED",
+        "submittedAt": "2026-05-11T17:00:00Z"
+      }
+    ],
+    "updatedAt": "2026-05-11T17:00:00Z"
+  }
+]

--- a/test/fixtures/repo/.bonanza.yml
+++ b/test/fixtures/repo/.bonanza.yml
@@ -1,0 +1,17 @@
+# Fixture config used by the test suite.
+# Tests that need different values can pass overrides to `with_config`.
+
+gh_handle: current_user
+
+search_limit: 20
+
+display_mode: full
+
+colorize: false
+
+searches:
+  - --label critical
+
+author_colors:
+
+label_colors:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "minitest/autorun"
+require "tmpdir"
+
+require_relative "../lib/bonanza"
+
+module FixtureHelpers
+  FIXTURE_DIR      = File.expand_path("fixtures", __dir__)
+  FIXTURE_REPO_DIR = File.join(FIXTURE_DIR, "repo")
+
+  def load_fixture(name)
+    JSON.parse(File.read(File.join(FIXTURE_DIR, "#{name}.json")))
+  end
+
+  def pr_fixture(number)
+    load_fixture("pr_list").find { |pr| pr["number"] == number } ||
+      raise("No PR ##{number} in pr_list fixture")
+  end
+end
+
+module ConfigHelpers
+  # Build a real Bonanza::Config from the fixture .bonanza.yml. When overrides
+  # are passed, the fixture is merged with them in a tempdir so individual
+  # tests can customize values without mutating the shared fixture on disk.
+  def build_fixture_config(overrides = {})
+    if overrides.empty?
+      Bonanza::Config.new(FixtureHelpers::FIXTURE_REPO_DIR)
+    else
+      base = YAML.load_file(File.join(FixtureHelpers::FIXTURE_REPO_DIR, ".bonanza.yml"))
+      merged = base.merge(overrides.transform_keys(&:to_s))
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, ".bonanza.yml"), YAML.dump(merged))
+        return Bonanza::Config.new(dir)
+      end
+    end
+  end
+
+  def with_config(overrides = {})
+    previous = Bonanza.config
+    Bonanza.config = build_fixture_config(overrides)
+    yield
+  ensure
+    Bonanza.config = previous
+  end
+end
+
+class Minitest::Test
+  include FixtureHelpers
+  include ConfigHelpers
+
+  def setup
+    Bonanza.options = {}
+    Bonanza.config  = build_fixture_config
+  end
+end


### PR DESCRIPTION
## Overview

Add unit tests framework and fixtures for common data. Include tests for `Formatter` and `Config`. Does not yet add tests for `Dashboard` or `Options`.

## Other changes

- Add `colorize` option to config with a default of `true`
- Rework the boot stack so that the main `Bonanza` module does not trigger requests on boot

## Testing

- [x] Tests pass: `bundle exec rake test`
- [x] Running on an active repo returns expected results 