### PR TITLE
Adjust My Review column based on required team reviews

### DIFF
--- a/lib/bonanza.rb
+++ b/lib/bonanza.rb
@@ -14,13 +14,14 @@ require_relative "bonanza/options"
 require_relative "bonanza/config"
 require_relative "bonanza/dashboard"
 require_relative "bonanza/formatter"
+require_relative "bonanza/github"
 
 module Bonanza
   class Error < StandardError; end
 
   class << self
     attr_accessor :repo_path
-    attr_writer :config, :options
+    attr_writer :config, :options, :my_teams
   end
 
   def self.logger
@@ -39,10 +40,15 @@ module Bonanza
     @config ||= Bonanza::Config.new(repo_path, options)
   end
 
+  def self.my_teams
+    @my_teams ||= Github.get_my_teams
+  end
+
   def self.boot(repo_path)
     self.repo_path = repo_path
     logger
     config
+    my_teams
   end
 
   def self.run(repo_path)

--- a/lib/bonanza/dashboard.rb
+++ b/lib/bonanza/dashboard.rb
@@ -8,6 +8,7 @@ module Bonanza
       { title: "Title", field: "title", compact: true },
       { title: "Review", field: "reviewDecision", compact: true },
       { field: "latestReviews", hidden: true },
+      { field: "reviewRequests", hidden: true },
       { title: "My Review", field: "myReview", computed: true, compact: true },
       { title: "PR #", field: "number", hidden: true },
       { title: "Author", field: "author", compact: true },
@@ -79,10 +80,8 @@ module Bonanza
     end
 
     def find_prs_by(search)
-      fields = search_columns.map { |c| c[:field] }.compact.join(",")
-      base = "PAGER=cat gh pr list --state open --limit #{@search_limit} --json #{fields}"
-      cmd = "#{base} #{search}"
-      JSON.parse(run_cmd(cmd))
+      fields = search_columns.map { |c| c[:field] }.compact
+      Bonanza::Github.search_prs(search, limit: @search_limit, fields: fields)
     end
 
     def print_table
@@ -113,11 +112,6 @@ module Bonanza
       table_title = Bonanza::Formatter.colorize("Bonanza! --- Pull requests for #{@gh_handle} (#{Bonanza.repo_path})", color: :white)
       table = Terminal::Table.new(title: table_title, rows: rows, headings: display_columns.map { |c| c[:title] })
       puts table
-    end
-
-    def run_cmd(cmd)
-      Bonanza.log_verbose("Running command: #{cmd}")
-      `cd #{Bonanza.repo_path}; #{cmd}`
     end
 
   end

--- a/lib/bonanza/formatter.rb
+++ b/lib/bonanza/formatter.rb
@@ -38,17 +38,29 @@ module Bonanza
     end
 
     def self.get_review_status(pr)
-      if pr["isDraft"]
-        ""
-      elsif pr["reviewDecision"].nil? || pr["reviewDecision"].empty?
-        "REQUIRED" # GH sometimes has empty reviewDecision for PRs that are open and have no reviews yet
-      else
-        PR_REVIEW_STATUS_MAP[pr["reviewDecision"]] || pr["reviewDecision"]
-      end
+      return "" if pr["isDraft"]
+
+      # GH sometimes has empty reviewDecision for PRs that are open and have no reviews yet
+      return "REQUIRED" if pr["reviewDecision"].nil? || pr["reviewDecision"].empty?
+
+      PR_REVIEW_STATUS_MAP[pr["reviewDecision"]] || pr["reviewDecision"]
     end
 
     def self.get_my_review_status(pr)
-      pr["latestReviews"].to_a.find { |r| r["author"]["login"] == Bonanza.config.gh_handle }.to_h["state"]
+      status = pr["latestReviews"].to_a.find { |r| r["author"]["login"] == Bonanza.config.gh_handle }.to_h["state"]
+      return status unless status.nil?
+
+      my_teams_satisfied?(pr) ? "" : "REQUIRED"
+    end
+
+    def self.my_teams_satisfied?(pr)
+      my_teams = Bonanza.my_teams
+      return true if my_teams.empty?
+
+      org = pr["url"].split("/")[3]
+      pr["reviewRequests"].to_a.none? do |req|
+        req["slug"] && my_teams.include?("#{org}/#{req['slug']}")
+      end
     end
 
     def self.format_priority(pr)

--- a/lib/bonanza/github.rb
+++ b/lib/bonanza/github.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Bonanza
+  module Github
+
+    def self.get_my_teams
+      Bonanza.log_verbose("Fetching user teams")
+      teams = JSON.parse(execute("gh api /user/teams --paginate"))
+      Set.new(teams.map { |t| "#{t['organization']['login']}/#{t['slug']}" })
+    rescue StandardError => e
+      Bonanza.log_verbose("Failed to fetch user teams: #{e.message}")
+      Set.new
+    end
+
+    def self.search_prs(search, limit:, fields:)
+      fields_arg = Array(fields).join(",")
+      cmd = "PAGER=cat gh pr list --state open --limit #{limit} --json #{fields_arg} #{search}"
+      JSON.parse(execute("cd #{Bonanza.repo_path}; #{cmd}"))
+    end
+
+    def self.execute(cmd)
+      Bonanza.log_verbose("Running command: #{cmd}")
+      `#{cmd}`
+    end
+
+  end
+end

--- a/test/bonanza/formatter_test.rb
+++ b/test/bonanza/formatter_test.rb
@@ -38,8 +38,8 @@ class FormatterTest < Minitest::Test
 
   # --- get_my_review_status -------------------------------------------------
 
-  def test_get_my_review_status_returns_nil_with_no_reviews
-    assert_nil Bonanza::Formatter.get_my_review_status(pr_fixture(101))
+  def test_get_my_review_status_returns_empty_with_no_reviews
+    assert_equal "", Bonanza::Formatter.get_my_review_status(pr_fixture(101))
   end
 
   def test_get_my_review_status_returns_state_when_user_has_reviewed
@@ -48,7 +48,29 @@ class FormatterTest < Minitest::Test
   end
 
   def test_get_my_review_status_ignores_reviews_from_other_users
-    assert_nil Bonanza::Formatter.get_my_review_status(pr_fixture(103))
+    assert_equal "", Bonanza::Formatter.get_my_review_status(pr_fixture(103))
+  end
+
+  def test_get_my_review_status_is_required_when_my_team_is_a_pending_reviewer
+    Bonanza.my_teams = Set.new(["example/team-monet"])
+    assert_equal "REQUIRED", Bonanza::Formatter.get_my_review_status(pr_fixture(107))
+  end
+
+  def test_get_my_review_status_is_empty_when_only_other_teams_are_pending_reviewers
+    Bonanza.my_teams = Set.new(["example/team-monet"])
+    assert_equal "", Bonanza::Formatter.get_my_review_status(pr_fixture(108))
+  end
+
+  def test_get_my_review_status_scopes_team_match_to_pr_org
+    # team slug matches but org does not — should not count as my team blocking
+    Bonanza.my_teams = Set.new(["other-org/team-monet"])
+    assert_equal "", Bonanza::Formatter.get_my_review_status(pr_fixture(107))
+  end
+
+  def test_get_my_review_status_personal_review_takes_precedence_over_team_request
+    Bonanza.my_teams = Set.new(["example/team-monet"])
+    # PR 106: I've already approved personally; team logic shouldn't override that.
+    assert_equal "APPROVED", Bonanza::Formatter.get_my_review_status(pr_fixture(106))
   end
 
   # --- format_priority ------------------------------------------------------

--- a/test/bonanza/github_test.rb
+++ b/test/bonanza/github_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class GithubTest < Minitest::Test
+
+  # Replaces Bonanza::Github.execute so tests never invoke the real CLI.
+  def stub_exec(output)
+    captured = []
+    Bonanza::Github.define_singleton_method(:execute) do |cmd|
+      captured << cmd
+      output
+    end
+    yield captured
+  ensure
+    Bonanza::Github.singleton_class.send(:remove_method, :execute)
+  end
+
+  def teams_fixture
+    File.read(File.join(FixtureHelpers::FIXTURE_DIR, "teams_list.json"))
+  end
+
+  # --- get_my_teams ---------------------------------------------------------
+
+  def test_get_my_teams_invokes_gh_user_teams_with_pagination
+    stub_exec("[]") do |captured|
+      Bonanza::Github.get_my_teams
+      assert_equal ["gh api /user/teams --paginate"], captured
+    end
+  end
+
+  def test_get_my_teams_returns_a_set
+    stub_exec("[]") do
+      assert_kind_of Set, Bonanza::Github.get_my_teams
+    end
+  end
+
+  def test_get_my_teams_maps_each_team_to_org_slash_slug
+    stub_exec(teams_fixture) do
+      teams = Bonanza::Github.get_my_teams
+
+      assert_equal Set.new(%w[
+        The-Salon-de-Paris/salon-patrons
+        the-met/painters
+        the-met/team-monet
+      ]), teams
+    end
+  end
+
+  def test_get_my_teams_returns_empty_set_when_user_has_no_teams
+    stub_exec("[]") do
+      assert_equal Set.new, Bonanza::Github.get_my_teams
+    end
+  end
+
+  def test_get_my_teams_returns_empty_set_when_output_is_blank
+    stub_exec("") do
+      assert_equal Set.new, Bonanza::Github.get_my_teams
+    end
+  end
+
+  def test_get_my_teams_returns_empty_set_when_output_is_not_json
+    stub_exec("gh: command not found") do
+      assert_equal Set.new, Bonanza::Github.get_my_teams
+    end
+  end
+
+  # --- search_prs -----------------------------------------------------------
+
+  def test_search_prs_builds_gh_pr_list_command_in_repo
+    Bonanza.repo_path = "/tmp/some-repo"
+    stub_exec("[]") do |captured|
+      Bonanza::Github.search_prs("--author vangogh", limit: 20, fields: %w[number title])
+      assert_equal [
+        "cd /tmp/some-repo; PAGER=cat gh pr list --state open --limit 20 --json number,title --author vangogh",
+      ], captured
+    end
+  ensure
+    Bonanza.repo_path = nil
+  end
+
+  def test_search_prs_parses_json_output
+    stub_exec('[{"number":101},{"number":102}]') do
+      result = Bonanza::Github.search_prs("--author vangogh", limit: 20, fields: %w[number])
+      assert_equal [{ "number" => 101 }, { "number" => 102 }], result
+    end
+  end
+
+end

--- a/test/fixtures/pr_list.json
+++ b/test/fixtures/pr_list.json
@@ -113,5 +113,36 @@
       }
     ],
     "updatedAt": "2026-05-11T17:00:00Z"
+  },
+  {
+    "number": 107,
+    "title": "Restore Water Lilies thumbnail caching",
+    "url": "https://github.com/example/repo/pull/107",
+    "isDraft": false,
+    "reviewDecision": "REVIEW_REQUIRED",
+    "author": { "login": "monet", "name": "Claude Monet" },
+    "assignees": [],
+    "labels": [],
+    "latestReviews": [],
+    "reviewRequests": [
+      { "__typename": "Team", "name": "team-monet", "slug": "team-monet" }
+    ],
+    "updatedAt": "2026-05-11T19:00:00Z"
+  },
+  {
+    "number": 108,
+    "title": "Tweak Sunflowers color palette",
+    "url": "https://github.com/example/repo/pull/108",
+    "isDraft": false,
+    "reviewDecision": "REVIEW_REQUIRED",
+    "author": { "login": "vangogh", "name": "Vincent van Gogh" },
+    "assignees": [],
+    "labels": [],
+    "latestReviews": [],
+    "reviewRequests": [
+      { "__typename": "Team", "name": "Sculptors", "slug": "sculptors" },
+      { "__typename": "User", "login": "rodin" }
+    ],
+    "updatedAt": "2026-05-11T19:30:00Z"
   }
 ]

--- a/test/fixtures/teams_list.json
+++ b/test/fixtures/teams_list.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "Salon Patrons",
+    "slug": "salon-patrons",
+    "organization": {
+      "login": "The-Salon-de-Paris",
+      "id": 17657977,
+      "type": "Organization"
+    },
+    "parent": null
+  },
+  {
+    "name": "Painters",
+    "slug": "painters",
+    "description": "Remember that there is no brushstroke faster than no brushstroke.",
+    "organization": {
+      "login": "the-met",
+      "id": 40865417,
+      "type": "Organization"
+    },
+    "parent": null
+  },
+  {
+    "name": "team-monet",
+    "slug": "team-monet",
+    "organization": {
+      "login": "the-met",
+      "id": 40865417,
+      "type": "Organization"
+    },
+    "parent": {
+      "name": "Painters",
+      "slug": "painters"
+    }
+  }
+]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,7 +51,8 @@ class Minitest::Test
   include ConfigHelpers
 
   def setup
-    Bonanza.options = {}
-    Bonanza.config  = build_fixture_config
+    Bonanza.options  = {}
+    Bonanza.config   = build_fixture_config
+    Bonanza.my_teams = Set.new
   end
 end


### PR DESCRIPTION
## Overview
The "Review" column lists overall required reviews, some of which may be dependent on other teams. The "My Review" column currently just tracks reviews that have been left by the user. What's missing is an indication that the user needs to review a PR (or could unblock it by their review), based on the team memberships and code owners rules.

**Changes:**
- Add a `Github` class for interacting with the GH CLI
- Pull user's team memberships for reference
- Augment "My Review" with requested reviews and team memberships

## Testing
- [x] Tests pass
- [x] Manual run passes