### PR TITLE
Fix tests associated with #my_teams_satisfied?

### DIFF
--- a/test/bonanza/formatter_test.rb
+++ b/test/bonanza/formatter_test.rb
@@ -52,12 +52,12 @@ class FormatterTest < Minitest::Test
   end
 
   def test_get_my_review_status_is_required_when_my_team_is_a_pending_reviewer
-    Bonanza.my_teams = Set.new(["example/team-monet"])
+    Bonanza.my_teams = Set.new(["the-met/team-monet"])
     assert_equal "REQUIRED", Bonanza::Formatter.get_my_review_status(pr_fixture(107))
   end
 
   def test_get_my_review_status_is_empty_when_only_other_teams_are_pending_reviewers
-    Bonanza.my_teams = Set.new(["example/team-monet"])
+    Bonanza.my_teams = Set.new(["the-met/team-monet"])
     assert_equal "", Bonanza::Formatter.get_my_review_status(pr_fixture(108))
   end
 
@@ -68,7 +68,7 @@ class FormatterTest < Minitest::Test
   end
 
   def test_get_my_review_status_personal_review_takes_precedence_over_team_request
-    Bonanza.my_teams = Set.new(["example/team-monet"])
+    Bonanza.my_teams = Set.new(["the-met/team-monet"])
     # PR 106: I've already approved personally; team logic shouldn't override that.
     assert_equal "APPROVED", Bonanza::Formatter.get_my_review_status(pr_fixture(106))
   end

--- a/test/fixtures/pr_list.json
+++ b/test/fixtures/pr_list.json
@@ -125,7 +125,7 @@
     "labels": [],
     "latestReviews": [],
     "reviewRequests": [
-      { "__typename": "Team", "name": "team-monet", "slug": "team-monet" }
+      { "__typename": "Team", "name": "team-monet", "slug": "the-met/team-monet" }
     ],
     "updatedAt": "2026-05-11T19:00:00Z"
   },
@@ -140,7 +140,7 @@
     "labels": [],
     "latestReviews": [],
     "reviewRequests": [
-      { "__typename": "Team", "name": "Sculptors", "slug": "sculptors" },
+      { "__typename": "Team", "name": "Sculptors", "slug": "the-met/sculptors" },
       { "__typename": "User", "login": "rodin" }
     ],
     "updatedAt": "2026-05-11T19:30:00Z"


### PR DESCRIPTION
# Overview

Fix tests associated with `#my_teams_satisfied?`. The tests were broken after fixing that method in 14722f4d0d30c523a885a5416bebe45f738535a6. 

The issue is that the teams API response lists `slug` as simply a normalized version of `name`, whereas the PR response for `reviewRequests` lists `slug` as `org/normalized-name`. This discrepancy was missed in the original implementation and is now fixed.

## Testing
- [x] Tests pass
- [x] Manual tests pass