### PR TITLE
[Fix] Don't display REQUIRED for My Review on authors own PRs

### DIFF
--- a/lib/bonanza/formatter.rb
+++ b/lib/bonanza/formatter.rb
@@ -136,6 +136,8 @@ module Bonanza
     end
 
     def self.get_my_review_status(pr)
+      return "" if pr["author"]["login"] == Bonanza.config.gh_handle
+
       status = pr["latestReviews"].to_a.find { |r| r["author"]["login"] == Bonanza.config.gh_handle }.to_h["state"]
       return normalize_review_status(status) unless status.nil?
 

--- a/test/bonanza/formatter_test.rb
+++ b/test/bonanza/formatter_test.rb
@@ -56,6 +56,12 @@ class FormatterTest < Minitest::Test
     assert_equal "REQUIRED", Bonanza::Formatter.get_my_review_status(pr_fixture(107))
   end
 
+  def test_get_my_review_status_is_empty_when_i_am_the_author_even_if_my_team_is_pending
+    Bonanza.my_teams = Set.new(["the-met/team-monet"])
+    pr = pr_fixture(107).merge("author" => { "login" => "current_user" })
+    assert_equal "", Bonanza::Formatter.get_my_review_status(pr)
+  end
+
   def test_get_my_review_status_is_empty_when_only_other_teams_are_pending_reviewers
     Bonanza.my_teams = Set.new(["the-met/team-monet"])
     assert_equal "", Bonanza::Formatter.get_my_review_status(pr_fixture(108))


### PR DESCRIPTION
## Overview
Fixes an issue where the "My Review" column could display "REQUIRED" for PRs that are authored by the current user. This is misleading because authors can't review their own work.

## Testing

- [x] Tests pass
- [x] Manual test passes