### PR TITLE
Add caching for Github teams fetch

### DIFF
--- a/lib/bonanza/github.rb
+++ b/lib/bonanza/github.rb
@@ -5,7 +5,7 @@ module Bonanza
 
     def self.get_my_teams
       Bonanza.log_verbose("Fetching user teams")
-      teams = JSON.parse(execute("gh api /user/teams --paginate"))
+      teams = JSON.parse(execute("gh api /user/teams --paginate --cache 24h"))
       Set.new(teams.map { |t| "#{t['organization']['login']}/#{t['slug']}" })
     rescue StandardError => e
       Bonanza.log_verbose("Failed to fetch user teams: #{e.message}")

--- a/test/bonanza/github_test.rb
+++ b/test/bonanza/github_test.rb
@@ -18,10 +18,10 @@ class GithubTest < Minitest::Test
 
   # --- get_my_teams ---------------------------------------------------------
 
-  def test_get_my_teams_invokes_gh_user_teams_with_pagination
+  def test_get_my_teams_invokes_gh_user_teams_with_pagination_and_cache
     stub_exec("[]") do |captured|
       Bonanza::Github.get_my_teams
-      assert_equal ["gh api /user/teams --paginate"], captured
+      assert_equal ["gh api /user/teams --paginate --cache 24h"], captured
     end
   end
 


### PR DESCRIPTION
## Overview

The teams fetch is additional overhead each time Bonanza runs, however it is unlikely that this data changes often. For now, cache the results for 24 hours. In the future we can add a cache busting mechanism, or a broader caching strategy if needed.

## Testing

- [x] Tests pass
- [x] Manual tests pass 